### PR TITLE
vacuum oven fix again

### DIFF
--- a/!dda/pngs_large_stuff_64x80/items/generic/microwave/microwave.json
+++ b/!dda/pngs_large_stuff_64x80/items/generic/microwave/microwave.json
@@ -1,8 +1,5 @@
 {
-  "id": [
-    [ "microwave" ],
-    [ "vac_oven_small" ]
-  ],
+  "id": "microwave",
   "fg": [
     "microwave"
   ],

--- a/!dda/pngs_large_stuff_64x80/items/generic/vac_oven_small/vac_oven_small.json
+++ b/!dda/pngs_large_stuff_64x80/items/generic/vac_oven_small/vac_oven_small.json
@@ -3,6 +3,8 @@
   "fg": [
     "microwave"
   ],
-  "bg": [],
+  "bg": [
+    
+  ],
   "rotates": false
 }


### PR DESCRIPTION
Reverts last fix since it caused tileset load errors. Replaces with new fix tested working. The microwave is a larger tile than what vacuum oven likely needs, so it needs to be placed in the larger tilesheet, not 32x32 like we had before

<img width="883" alt="Screenshot 2023-02-18 at 7 12 46 PM" src="https://user-images.githubusercontent.com/26608431/219905243-d6cd5ad6-4f8e-4839-920f-0790fa324834.png">
