### PR TITLE
Add z-level creature shadows

### DIFF
--- a/!dda/pngs_normal_stuff_32x32/hardcode/shadow/shadow.json
+++ b/!dda/pngs_normal_stuff_32x32/hardcode/shadow/shadow.json
@@ -1,0 +1,6 @@
+{
+    "id": "shadow",
+    "fg": [
+      "bg_shadow_normal"
+    ]
+}


### PR DESCRIPTION
Added json assignment for shadows of creatures in higher z-levels using existing normal sized shadow sprite. (https://github.com/CleverRaven/Cataclysm-DDA/pull/66730)